### PR TITLE
Add dark mode styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,18 +38,25 @@ html {
 body {
   background-color: var(--background);
   color: var(--foreground);
-
-  @variant sm {
-    background-image: linear-gradient(
-      to bottom right,
-      #f8f8f8,
-      var(--background) 20%
-    );
-    background-repeat: no-repeat;
-  }
 }
 
 svg {
   display: block;
   flex-shrink: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #121212;
+    --foreground: #f5f5f5;
+    --color-screen: #1e1e1e;
+    --color-black-10: rgba(255, 255, 255, 0.1);
+    --color-black-50: rgba(255, 255, 255, 0.5);
+    --shadow-textarea: rgba(255, 255, 255, 0.15) 0px 1px 2px 0px inset,
+      rgba(255, 255, 255, 0.08) 1px -2px 2px 0px inset;
+  }
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+  }
 }

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -142,4 +142,35 @@
   .Button[data-selected] .LED {
     background: var(--primary);
   }
+
+  @media (prefers-color-scheme: dark) {
+    .Button {
+      background: #2b2b2b;
+      box-shadow: inset 1px 1px 1px #00000080,
+        inset -1px -1px 1px #ffffff1a,
+        0.444584px 0.444584px 0.628737px -1px #00000066,
+        1.21072px 1.21072px 1.71222px -1.5px #00000059,
+        2.6583px 2.6583px 3.75941px -2.25px #0000004f,
+        5.90083px 5.90083px 8.34503px -3px #00000040,
+        10px 10px 21.2132px -3.75px #00000026,
+        -0.5px -0.5px 0 0 rgb(255 255 255 / 5%);
+    }
+
+    .Button:active,
+    .Button[data-selected] {
+      box-shadow: inset 0.5px 0.5px 1px #000,
+        inset -0.5px -0.5px 1px #ffffff33,
+        0.222px 0.222px 0.314px -0.5px #0003,
+        0.605px 0.605px 0.856px -1px #0000005e,
+        1.329px 1.329px 1.88px -1.5px #00000080,
+        2.95px 2.95px 4.172px -2px #0000003d,
+        2.5px 2.5px 3px -2.5px #00000040,
+        -0.5px -0.5px 0 0 rgb(255 255 255 / 10%);
+    }
+
+    .LED {
+      background-color: rgba(255, 255, 255, 0.1);
+      box-shadow: inset 1px 1px 2px #ffffff1c, 0 1px 0 0px #00000030;
+    }
+  }
 }

--- a/src/components/ui/Footer.module.css
+++ b/src/components/ui/Footer.module.css
@@ -30,3 +30,13 @@
   animation: wave 1.2s cubic-bezier(0.37, 0, 0.63, 1) infinite;
   opacity: 1;
 }
+
+@media (prefers-color-scheme: dark) {
+  .Footer {
+    background: #1a1a1ab3;
+  }
+
+  [data-scrollable="true"] .Footer {
+    border-top: 1px solid #333;
+  }
+}

--- a/src/components/ui/Switcher.module.css
+++ b/src/components/ui/Switcher.module.css
@@ -36,3 +36,20 @@
 .Track[data-state="checked"] .Thumb {
   transform: translateX(19px);
 }
+
+@media (prefers-color-scheme: dark) {
+  .Track {
+    box-shadow: inset 0 1px 2px #ffffff26, 0 1px 0 0 #00000040;
+    background: rgba(255, 255, 255, 0.15);
+  }
+
+  .Thumb {
+    background: #2b2b2b;
+    box-shadow: inset 1px 1px 1px #000,
+      inset -1px -1px 0px #ffffff26, 0.444584px 0.444584px 0.628737px -0.75px #000000a6,
+      1.21072px 1.21072px 1.71222px -1.5px #0000008f,
+      2.6583px 2.6583px 3.75941px -2.25px #0000007b,
+      5.90083px 5.90083px 8.34503px -3px #00000066,
+      10px 10px 21.2132px -3.75px #00000040;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a dark color scheme by swapping CSS variables when `prefers-color-scheme: dark` and remove the old gradient background
- tune component styles (buttons, switcher, footer) so their surfaces and shadows adapt to the dark palette

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_i_6893fc075e748333847a0a0aff490b57