### PR TITLE
feat: add dark mode design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,15 +5,33 @@
   --foreground: #222;
   --primary: #ff4a00;
   --page-max-width: 1300px;
+  --color-screen: #f3f3f3;
+  --color-black-10: rgba(0, 0, 0, 0.1);
+  --color-black-50: rgba(0, 0, 0, 0.5);
+  --shadow-textarea: rgba(0, 0, 0, 0.15) 0px 1px 2px 0px inset,
+    rgba(0, 0, 0, 0.08) 1px -2px 2px 0px inset;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: #111;
+    --foreground: #f3f3f3;
+    --primary: #ff4a00;
+    --color-screen: #1e1e1e;
+    --color-black-10: rgba(255, 255, 255, 0.1);
+    --color-black-50: rgba(255, 255, 255, 0.5);
+    --shadow-textarea: rgba(0, 0, 0, 0.6) 0px 1px 2px 0px inset,
+      rgba(0, 0, 0, 0.4) 1px -2px 2px 0px inset;
+  }
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-primary: var(--primary);
-  --color-screen: #f3f3f3;
-  --color-black-10: rgba(0, 0, 0, 0.1);
-  --color-black-50: rgba(0, 0, 0, 0.5);
+  --color-screen: var(--color-screen);
+  --color-black-10: var(--color-black-10);
+  --color-black-50: var(--color-black-50);
 }
 
 @theme static {
@@ -26,8 +44,7 @@
   --radius-3xl: 1.5rem;
   --radius-4xl: 2rem;
 
-  --shadow-textarea: rgba(0, 0, 0, 0.15) 0px 1px 2px 0px inset,
-    rgba(0, 0, 0, 0.08) 1px -2px 2px 0px inset;
+  --shadow-textarea: var(--shadow-textarea);
 }
 
 html {
@@ -46,6 +63,21 @@ body {
       var(--background) 20%
     );
     background-repeat: no-repeat;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+
+    @variant sm {
+      background-image: linear-gradient(
+        to bottom right,
+        #000,
+        var(--background) 20%
+      );
+    }
   }
 }
 

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -142,4 +142,46 @@
   .Button[data-selected] .LED {
     background: var(--primary);
   }
+
+  @media (prefers-color-scheme: dark) {
+    .Button {
+      background: #2a2a2a;
+      box-shadow: inset 1px 1px 1px #ffffff1a, inset -1px -1px 1px #00000080,
+        0.444584px 0.444584px 0.628737px -1px #00000066,
+        1.21072px 1.21072px 1.71222px -1.5px #00000066,
+        2.6583px 2.6583px 3.75941px -2.25px #00000059,
+        5.90083px 5.90083px 8.34503px -3px #0000004d,
+        10px 10px 21.2132px -3.75px #00000040,
+        -0.5px -0.5px 0 0 rgba(0, 0, 0, 0.6);
+    }
+
+    .Button:active,
+    .Button[data-selected] {
+      box-shadow: inset 0.5px 0.5px 1px #ffffff33,
+        inset -0.5px -0.5px 1px #00000099,
+        0.222px 0.222px 0.314px -1px #0003,
+        0.605px 0.605px 0.856px -1px #00000066,
+        1.329px 1.329px 1.88px -1.5px #00000080,
+        2.95px 2.95px 4.172px -2px #0000004d,
+        2.5px 2.5px 3px -2.5px #00000066,
+        -0.5px -0.5px 0 0 rgba(0, 0, 0, 0.6);
+    }
+
+    .Button[data-color="secondary"] {
+      background: #000;
+    }
+
+    .Button[data-color="tertiary"] {
+      background: #333;
+    }
+
+    .Button[data-color="neutral"] {
+      background: #444;
+    }
+
+    .LED {
+      background-color: rgba(255, 255, 255, 0.1);
+      box-shadow: inset 1px 1px 2px #0006, 0 1px 0 0px #ffffff30;
+    }
+  }
 }

--- a/src/components/ui/Footer.module.css
+++ b/src/components/ui/Footer.module.css
@@ -26,6 +26,16 @@
   }
 }
 
+@media (prefers-color-scheme: dark) {
+  .Footer {
+    background: #00000070;
+  }
+
+  [data-scrollable="true"] .Footer {
+    border-top: 1px solid #000;
+  }
+}
+
 .animate-wave {
   animation: wave 1.2s cubic-bezier(0.37, 0, 0.63, 1) infinite;
   opacity: 1;

--- a/src/components/ui/Switcher.module.css
+++ b/src/components/ui/Switcher.module.css
@@ -36,3 +36,20 @@
 .Track[data-state="checked"] .Thumb {
   transform: translateX(19px);
 }
+
+@media (prefers-color-scheme: dark) {
+  .Track {
+    box-shadow: inset 0 1px 2px #00000060, 0 1px 0 0 #ffffff10;
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .Thumb {
+    background: #1e1e1e;
+    box-shadow: inset 1px 1px 1px #ffffff1a, inset -1px -1px 0px #00000080,
+      0.444584px 0.444584px 0.628737px -0.75px #00000066,
+      1.21072px 1.21072px 1.71222px -1.5px #00000066,
+      2.6583px 2.6583px 3.75941px -2.25px #00000059,
+      5.90083px 5.90083px 8.34503px -3px #0000004d,
+      10px 10px 21.2132px -3.75px #00000040;
+  }
+}


### PR DESCRIPTION
## Summary
- add global dark mode variables and styling
- update buttons, footer, and switcher for dark theme

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run build` (fails: Failed to fetch font `JetBrains Mono`)

------
https://chatgpt.com/codex/tasks/task_i_689681ec2d288333a2ea4a6a7dce949d