### PR TITLE
feat: add dark mode

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,17 @@
   --foreground: #222;
   --primary: #ff4a00;
   --page-max-width: 1300px;
+  --background-start: #f8f8f8;
+  color-scheme: light dark;
+}
+
+.dark {
+  --background: #1b1b1b;
+  --foreground: #e9e9e9;
+  --color-screen: #1f1f1f;
+  --color-black-10: rgba(255, 255, 255, 0.1);
+  --color-black-50: rgba(255, 255, 255, 0.5);
+  --background-start: #111;
 }
 
 @theme inline {
@@ -42,7 +53,7 @@ body {
   @variant sm {
     background-image: linear-gradient(
       to bottom right,
-      #f8f8f8,
+      var(--background-start),
       var(--background) 20%
     );
     background-repeat: no-repeat;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { JetBrains_Mono } from "next/font/google";
+import Script from "next/script";
 import clsx from "clsx";
 import "./globals.css";
 
@@ -37,8 +38,23 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <body className={clsx("antialiased", jetBrainsMono.className)}>
+        <Script
+          id="theme-init"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `(() => {
+              try {
+                const theme = localStorage.getItem('theme');
+                const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+                if (theme === 'dark' || (!theme && prefersDark)) {
+                  document.documentElement.classList.add('dark');
+                }
+              } catch {}
+            })();`,
+          }}
+        />
         {children}
       </body>
     </html>

--- a/src/components/ui/Header.tsx
+++ b/src/components/ui/Header.tsx
@@ -1,5 +1,6 @@
 import { useAudioClip } from "@/hooks/useAudioClip";
 import { Switcher } from "./Switcher";
+import { ThemeSwitcher } from "./theme-switcher";
 import clsx from "clsx";
 import { External } from "./Icons";
 
@@ -51,7 +52,8 @@ export const Header = ({ devMode, setDevMode }: HeaderProps) => {
           </div>
         </div>
         <div className="col-span-10 md:col-span-3 xl:col-span-4 flex justify-end items-start order-2 md:order-3">
-          <div className="relative -top-[0.57rem]">
+          <div className="relative -top-[0.57rem] flex items-center gap-x-4">
+            <ThemeSwitcher />
             <Switcher
               checked={devMode}
               onChange={(checked) => setDevMode(checked)}

--- a/src/components/ui/Icons.tsx
+++ b/src/components/ui/Icons.tsx
@@ -188,8 +188,46 @@ export const Check = (props: IconProps) => {
       <path
         fillRule="evenodd"
         clipRule="evenodd"
-        d="M27.2923 9.55399L15.6198 26.6737C15.494 26.8582 15.2925 26.977 15.0701 26.9979C14.8478 27.0187 14.6277 26.9394 14.4698 26.7815L7.18945 19.5012L8.25011 18.4405L14.8904 25.0808L26.0529 8.70898L27.2923 9.55399Z"
+      d="M27.2923 9.55399L15.6198 26.6737C15.494 26.8582 15.2925 26.977 15.0701 26.9979C14.8478 27.0187 14.6277 26.9394 14.4698 26.7815L7.18945 19.5012L8.25011 18.4405L14.8904 25.0808L26.0529 8.70898L27.2923 9.55399Z"
       />
+    </svg>
+  );
+};
+
+export const Sun = (props: IconProps) => {
+  return (
+    <svg
+      width="36"
+      height="36"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M12 3v1.5M12 19.5V21M4.219 4.219l1.061 1.061M18.72 18.72l1.061 1.061M3 12h1.5M19.5 12H21M4.219 19.781l1.061-1.061M18.72 5.28l1.061-1.061M12 8.25a3.75 3.75 0 1 1 0 7.5 3.75 3.75 0 0 1 0-7.5z" />
+    </svg>
+  );
+};
+
+export const Moon = (props: IconProps) => {
+  return (
+    <svg
+      width="36"
+      height="36"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M21.752 15.002A9.718 9.718 0 0 1 12.004 21.75 9.75 9.75 0 0 1 9.819 2.75a9.712 9.712 0 0 1 .675.03A7.5 7.5 0 0 0 21.752 15.002z" />
     </svg>
   );
 };

--- a/src/components/ui/theme-switcher.tsx
+++ b/src/components/ui/theme-switcher.tsx
@@ -1,0 +1,25 @@
+import { useTheme } from "@/hooks/use-theme";
+import { useAudioClip } from "@/hooks/useAudioClip";
+import { Sun, Moon } from "./Icons";
+
+export function ThemeSwitcher() {
+  const { theme, toggleTheme } = useTheme();
+  const play = useAudioClip("/click.wav");
+
+  return (
+    <button
+      className="cursor-pointer hover:text-current/70 transition-colors"
+      aria-label="Toggle dark mode"
+      onClick={() => {
+        play();
+        toggleTheme();
+      }}
+    >
+      {theme === "dark" ? (
+        <Sun className="w-[2.29rem] h-[2.29rem]" />
+      ) : (
+        <Moon className="w-[2.29rem] h-[2.29rem]" />
+      )}
+    </button>
+  );
+}

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+export function useTheme() {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === "undefined") {
+      return "light";
+    }
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") {
+      return stored;
+    }
+    return window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  };
+
+  return { theme, setTheme, toggleTheme };
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,4 +1,5 @@
 const config = {
+  darkMode: "class",
   content: [
     "./src/**/*.{html,js,jsx,ts,tsx}", // adjust paths as needed
     "./public/**/*.html",


### PR DESCRIPTION
## Summary
- add a theme switcher to toggle dark mode
- update global styles and Tailwind config for dark theming
- initialize the document theme before hydration

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_i_68a4e17492248333a3838e5d751870e1